### PR TITLE
docs: replace placeholder README with comprehensive version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# cafe-menu
+# HTML and CSS Cafe Menu
+
+A responsive cafe menu created with HTML and CSS. This project is a practical application of the fundamental concepts 
+learned in the freeCodeCamp "Responsive Web Design" certification.
+
+This project is built by following the "Learn Basic CSS by Building a Cafe Menu" tutorial on freeCodeCamp. You can see 
+the starting point of the tutorial [here](https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/step-1).
+
+## 🚀 Project Objective
+
+The primary goal of this project is to build a visually appealing and well-structured web page using core HTML and
+CSS skills. It serves as a hands-on exercise to solidify the understanding of concepts taught by freeCodeCamp.
+
+### Key Learning Goals Applied:
+
+*   **Semantic HTML:** Structuring the content logically for both browsers and developers.
+*   **CSS Fundamentals:** Applying styles using various selectors, properties, and values.
+*   **The Box Model:** Mastering the concepts of `margin`, `padding`, `border`, and `content`.
+*   **Typography:** Styling text elements to create a readable and aesthetically pleasing menu.
+*   **Layout Techniques:** Using CSS to position and align elements, such as centering content.
+
+## 🛠️ Technologies Used
+
+*   **HTML5:** For the structure and content of the cafe menu.
+*   **CSS3:** For all styling, including colors, fonts, spacing, and layout.
+
+## ⚙️ Getting Started
+
+To view or work on this project locally, clone the repository and open the `index.html` file in your web browser.
+
+```bash
+# Clone this repository to your local machine
+git clone https://github.com/your-username/cafe-menu.git
+
+# Navigate into the cloned directory
+cd cafe-menu
+
+# Open the index.html file in your default web browser
+# (On macOS)
+open index.html
+# (On Windows)
+start index.html
+# (On Linux)
+xdg-open index.html
+```
+
+## 🙏 Acknowledgments
+
+A huge thank you to freeCodeCamp for providing an excellent, accessible, and free platform for learning web development. 
+This project is a direct result of their high-quality curriculum and hands-on teaching approach.
+
+## 📄 License
+This project is open-source and available under the **MIT License**.


### PR DESCRIPTION
The initial README generated by GitHub is a generic placeholder that lacks context. It fails to provide any meaningful information about the project's purpose, its educational goals, or how to run it.

This commit replaces that file with a detailed document to make the project self-explanatory from the start. It adds key sections covering the project's objectives, the technologies used, and clear setup instructions to provide immediate value and clarity for any visitor or contributor.