### PR TITLE
chore: ignore JetBrains .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# JetBrains IDE configuration folder
+.idea/


### PR DESCRIPTION
Update the .gitignore to exclude the .idea directory. This folder is generated by JetBrains IDEs and contains user-specific settings that should not be part of the shared project history.