### PR TITLE
feat: Add coffee section image

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
             <p>Est. 2020</p>
             <section>
                 <h2>Coffee</h2>
+                <img src="https://cdn.freecodecamp.org/curriculum/css-cafe/coffee.jpg" alt="coffee icon">
             </section>
             <section></section>
         </main>


### PR DESCRIPTION
The coffee section currently contains only a text heading, which is functionally correct but lacks visual appeal.

This commit introduces a decorative image to the section. Adding this visual element enhances the menu's aesthetic, provides thematic context for the upcoming coffee items, and makes the page more engaging for the user.