### PR TITLE
feat: add coffee menu items

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,21 @@
             <section>
                 <h2>Coffee</h2>
                 <img src="https://cdn.freecodecamp.org/curriculum/css-cafe/coffee.jpg" alt="coffee icon">
+                <article>
+                    <p>French Vanilla</p><p>3.00</p>
+                </article>
+                <article>
+                    <p>Caramel Macchiato</p><p>3.75</p>
+                </article>
+                <article>
+                    <p>Pumpkin Spice</p><p>3.50</p>
+                </article>
+                <article>
+                    <p>Hazelnut</p><p>4.00</p>
+                </article>
+                <article>
+                    <p>Mocha</p><p>4.50</p>
+                </article>
             </section>
             <section></section>
         </main>


### PR DESCRIPTION
The coffee section previously contained only a heading, providing no actual product information to the user.

This commit populates the section with the initial list of coffee offerings and their prices. This makes the menu functional by displaying the core products that a customer can order.