### PR TITLE
feat: add desserts section heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,9 @@
                     <p>Mocha</p><p>4.50</p>
                 </article>
             </section>
-            <section></section>
+            <section>
+                <h2>Desserts</h2>
+            </section>
         </main>
         <footer></footer>
     </body>


### PR DESCRIPTION
The menu structure currently contains an empty second section, which serves as an unlabeled placeholder without a clear purpose.

This commit introduces a heading for "Desserts". This provides a visible title for the next category of items and creates the necessary structure for populating the dessert menu, similar to the existing coffee section.