### PR TITLE
feat: add dessert section image

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
             </section>
             <section>
                 <h2>Desserts</h2>
+                <img src="https://cdn.freecodecamp.org/curriculum/css-cafe/pie.jpg" alt="pie icon">
             </section>
         </main>
         <footer></footer>


### PR DESCRIPTION
The dessert section currently consists only of a text heading, which is purely functional and lacks visual appeal.

This commit introduces a decorative image below the heading. This visual element enhances the section's aesthetic, provides thematic context for the upcoming dessert items, and makes the menu more engaging for the user.