### PR TITLE
feat: add website link to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,10 @@
                 </article>
             </section>
         </main>
-        <footer></footer>
+        <footer>
+            <p>
+                <a href="https://www.freecodecamp.org" target="_blank">Visit our website</a>
+            </p>
+        </footer>
     </body>
 </html>


### PR DESCRIPTION
The footer section is currently an empty placeholder and provides no additional information or navigation for the user.

This commit makes the footer functional by adding a "Visit our website" link that directs to freeCodeCamp. This provides a useful external link and serves as a credit to the source of the project's tutorial.