### PR TITLE
feat: add placeholder address to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
             <p>
                 <a href="https://www.freecodecamp.org" target="_blank">Visit our website</a>
             </p>
+            <p>123 Free Code Camp Drive</p>
         </footer>
     </body>
 </html>


### PR DESCRIPTION
The footer currently provides a link but lacks physical location info, an expected element for a business like a cafe.

This commit adds a placeholder address that references the project's source (freeCodeCamp). This makes the footer's content feel more complete and serves as a structural example for where a real business address would be placed.