### PR TITLE
feat: add colored background to menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,50 +7,52 @@
         <link rel="stylesheet" href="styles.css">
     </head>
     <body>
-        <main>
-            <h1>CAMPER CAFE</h1>
-            <p>Est. 2020</p>
-            <section>
-                <h2>Coffee</h2>
-                <img src="https://cdn.freecodecamp.org/curriculum/css-cafe/coffee.jpg" alt="coffee icon">
-                <article>
-                    <p>French Vanilla</p><p>3.00</p>
-                </article>
-                <article>
-                    <p>Caramel Macchiato</p><p>3.75</p>
-                </article>
-                <article>
-                    <p>Pumpkin Spice</p><p>3.50</p>
-                </article>
-                <article>
-                    <p>Hazelnut</p><p>4.00</p>
-                </article>
-                <article>
-                    <p>Mocha</p><p>4.50</p>
-                </article>
-            </section>
-            <section>
-                <h2>Desserts</h2>
-                <img src="https://cdn.freecodecamp.org/curriculum/css-cafe/pie.jpg" alt="pie icon">
-                <article>
-                    <p>Donut</p><p>1.50</p>
-                </article>
-                <article>
-                    <p>Cherry Pie</p><p>2.75</p>
-                </article>
-                <article>
-                    <p>Cheesecake</p><p>3.00</p>
-                </article>
-                <article>
-                    <p>Cinnamon Roll</p><p>2.50</p>
-                </article>
-            </section>
-        </main>
-        <footer>
-            <p>
-                <a href="https://www.freecodecamp.org" target="_blank">Visit our website</a>
-            </p>
-            <p>123 Free Code Camp Drive</p>
-        </footer>
+        <div class="menu">
+            <main>
+                <h1>CAMPER CAFE</h1>
+                <p>Est. 2020</p>
+                <section>
+                    <h2>Coffee</h2>
+                    <img src="https://cdn.freecodecamp.org/curriculum/css-cafe/coffee.jpg" alt="coffee icon">
+                    <article>
+                        <p>French Vanilla</p><p>3.00</p>
+                    </article>
+                    <article>
+                        <p>Caramel Macchiato</p><p>3.75</p>
+                    </article>
+                    <article>
+                        <p>Pumpkin Spice</p><p>3.50</p>
+                    </article>
+                    <article>
+                        <p>Hazelnut</p><p>4.00</p>
+                    </article>
+                    <article>
+                        <p>Mocha</p><p>4.50</p>
+                    </article>
+                </section>
+                <section>
+                    <h2>Desserts</h2>
+                    <img src="https://cdn.freecodecamp.org/curriculum/css-cafe/pie.jpg" alt="pie icon">
+                    <article>
+                        <p>Donut</p><p>1.50</p>
+                    </article>
+                    <article>
+                        <p>Cherry Pie</p><p>2.75</p>
+                    </article>
+                    <article>
+                        <p>Cheesecake</p><p>3.00</p>
+                    </article>
+                    <article>
+                        <p>Cinnamon Roll</p><p>2.50</p>
+                    </article>
+                </section>
+            </main>
+            <footer>
+                <p>
+                    <a href="https://www.freecodecamp.org" target="_blank">Visit our website</a>
+                </p>
+                <p>123 Free Code Camp Drive</p>
+            </footer>
+        </div>
     </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
 body {
     background-image: url("https://cdn.freecodecamp.org/curriculum/css-cafe/beans.jpg");
 }
+
+.menu {
+    background-color: #deb887;
+}


### PR DESCRIPTION
The menu text currently appears directly on top of the page's background image, which compromises readability and visual organization.

This commit introduces a solid-colored background for the main menu area. This creates a distinct visual block for the menu, significantly improving text contrast and making the content easier to read.