### PR TITLE
feat: center all text elements

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,3 +5,7 @@ body {
 .menu {
     background-color: #deb887;
 }
+
+h1, h2, p {
+    text-align: center;
+}


### PR DESCRIPTION
The headings and paragraphs are currently left-aligned by default, which creates a visual imbalance within the overall centered menu design.

This commit applies text-centering to all h1, h2, and p elements. This change creates a more symmetrical and cohesive look, aligning the text content with the centered layout aesthetic.