### PR TITLE
feat: constrain and center main menu

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,11 @@ body {
 }
 
 .menu {
+    width: 80%;
     background-color: #deb887;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 500px;
 }
 
 h1, h2, p {


### PR DESCRIPTION
The menu container currently spans the full width of the viewport. This results in an unprofessional, stretched appearance on wide screens and leads to overly long line lengths, which harm readability.

This commit constrains the menu to a responsive width with a defined maximum size, and centers the entire block on the page. This creates