### PR TITLE
feat: center section images

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -13,3 +13,9 @@ body {
 h1, h2, p {
     text-align: center;
 }
+
+img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}


### PR DESCRIPTION
The decorative images are currently left-aligned by default, which disrupts the visual symmetry established by the centered text and menu block.

This commit horizontally centers all images within their parent sections. This change brings the images into alignment with the overall design aesthetic, creating a more balanced and polished layout.