### PR TITLE
feat: set sans-serif as default page font

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,6 @@
 body {
     background-image: url("https://cdn.freecodecamp.org/curriculum/css-cafe/beans.jpg");
+    font-family: sans-serif;
 }
 
 .menu {


### PR DESCRIPTION
The page currently relies on the browser's default font, which is often a serif typeface. This can lead to an inconsistent or less modern appearance across different systems.

This commit establishes a `sans-serif` font as the base typography for the entire page. This change ensures a cleaner, more modern look and improves overall readability for the menu's content.