### PR TITLE
feat: establish heading font size hierarchy

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,14 @@ body {
     max-width: 500px;
 }
 
+h1 {
+    font-size: 40px;
+}
+
+h2 {
+    font-size: 30px;
+}
+
 h1, h2 {
     font-family: Impact, serif;
 }


### PR DESCRIPTION
The headings currently rely on default browser font sizes, which lack the necessary visual weight and distinction for a stylized menu design.

This commit defines explicit font sizes for the h1 and h2 elements. This change establishes a clear typographic scale, reinforces the structural importance of each heading, and significantly improves the page's visual hierarchy.