### PR TITLE
feat: set font size for menu items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -35,6 +35,7 @@ img {
 
 .item p {
     display: inline-block;
+    font-size: 18px;
 }
 
 .flavor, .dessert {


### PR DESCRIPTION
The menu items currently inherit the base body font size, which may not be ideal for the detailed, two-column list format of the menu.

This commit applies a specific font size to all menu item and price elements. This improves readability within the menu layout and establishes a deliberate typographic style for the core content.