### PR TITLE
feat: reduce spacing above section images

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,7 @@ img {
     display: block;
     margin-left: auto;
     margin-right: auto;
+    margin-top: -25px;
 }
 
 .item p {


### PR DESCRIPTION
The default vertical space between the section headings and their associated images is currently too large. This creates a visual disconnect between a section's title and its graphic.

This commit reduces the top margin on the images, pulling them closer to the headings above. This change creates a more cohesive and visually grouped section, improving the overall layout flow.