### PR TITLE
feat: add vertical spacing to menu items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,8 @@ img {
 
 .item p {
     display: inline-block;
+    margin-top: 5px;
+    margin-bottom: 5px;
     font-size: 18px;
 }
 


### PR DESCRIPTION
The vertical spacing between menu items is currently determined by default browser and line-height settings, which lacks intentional design control.

This commit introduces explicit top and bottom margins to each item. This establishes a deliberate and consistent 'breathing room' between the menu offerings, improving the layout's rhythm and overall readability. Why This Version is More Accurate: