### PR TITLE
feat: add padding to menu container

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,11 +4,12 @@ body {
 }
 
 .menu {
-    width: 80%;
     background-color: #deb887;
+    width: 80%;
     margin-left: auto;
     margin-right: auto;
     max-width: 500px;
+    padding: 20px;
 }
 
 h1 {


### PR DESCRIPTION
The content inside the menu currently touches the edges of its background container. This creates a cramped appearance and lacks a professional, polished look.

This commit adds internal padding to the menu block. This creates essential "breathing room" around the content, improving the layout's visual balance and overall aesthetic.