### PR TITLE
feat: add padding to page body

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,7 @@
 body {
     background-image: url("https://cdn.freecodecamp.org/curriculum/css-cafe/beans.jpg");
     font-family: sans-serif;
+    padding: 20px;
 }
 
 .menu {


### PR DESCRIPTION
The main menu container can currently touch the edges of the browser viewport, especially on smaller screens. This creates a visually cramped and unprofessional appearance.

This commit applies padding to the body element. This ensures there is always a consistent visual buffer around the main content, improving the overall layout and preventing it from touching the screen edges.