### PR TITLE
feat: adjust vertical margins for main heading

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,8 @@ body {
 
 h1 {
     font-size: 40px;
+    margin-top: 0;
+    margin-bottom: 15px;
 }
 
 h2 {


### PR DESCRIPTION
The h1 element currently retains its default browser margins, which creates excessive and uncontrolled empty space above the main title.

This commit removes the top margin and defines a specific bottom margin. This change provides precise control over the header's vertical spacing, resulting in a more compact and intentionally designed layout.