### PR TITLE
feat: adjust spacing above footer divider

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                     </article>
                 </section>
             </main>
-            <hr>
+            <hr class="bottom-line">
             <footer>
                 <p>
                     <a href="https://www.freecodecamp.org" target="_blank">Visit our website</a>

--- a/styles.css
+++ b/styles.css
@@ -64,3 +64,7 @@ hr {
     width: 25%;
     text-align: right;
 }
+
+.bottom-line {
+    margin-top: 25px;
+}


### PR DESCRIPTION
The horizontal rule before the footer currently uses a default browser margin, which may not align with the intended vertical rhythm of the layout.

This commit targets the specific divider to apply a custom top margin. This provides deliberate control over the vertical spacing, creating a more balanced and visually appealing separation between the main content and the footer.