### PR TITLE
feat: set footer font size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -68,3 +68,9 @@ hr {
 .bottom-line {
     margin-top: 25px;
 }
+
+/* FOOTER */
+
+footer {
+    font-size: 14px;
+}


### PR DESCRIPTION
The footer text currently inherits the default body font size, which gives it the same visual prominence as the primary menu content.

This commit applies a smaller, specific font size to the footer. This visually de-emphasizes the content, creating a clearer hierarchy and signaling that it is secondary information.