### PR TITLE
feat: style footer link and pseudo-classes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -74,3 +74,16 @@ hr {
 footer {
     font-size: 14px;
 }
+
+a {
+    color: #000000;
+    &:visited {
+        color: #000000;
+    }
+    &:hover {
+        color: #a52a2a;
+    }
+    &:active {
+        color: #a52a2a;
+    }
+}


### PR DESCRIPTION
The footer link is currently unstyled, relying on the browser's default blue and purple colors. This clashes with the established aesthetic of the cafe menu and provides no clear feedback on interaction.

This commit applies custom styling to the link's default, visited, hover, and active states. This integrates the link cohesively into the design and provides clear visual feedback to the user during interaction.