### PR TITLE
feat: adjust bottom margin of footer address

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                 <p>
                     <a href="https://www.freecodecamp.org" target="_blank">Visit our website</a>
                 </p>
-                <p>123 Free Code Camp Drive</p>
+                <p class="address">123 Free Code Camp Drive</p>
             </footer>
         </div>
     </body>

--- a/styles.css
+++ b/styles.css
@@ -87,3 +87,7 @@ a {
         color: #a52a2a;
     }
 }
+
+.address {
+    margin-bottom: 5px;
+}


### PR DESCRIPTION
The address line in the footer currently sits flush against the bottom of the menu container, which looks cramped and unbalanced.

This commit adds a bottom margin to the address paragraph. This creates deliberate 'breathing room' at the very end of the menu, providing a more polished and visually complete layout.