### PR TITLE
docs: update clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To view or work on this project locally, clone the repository and open the `inde
 
 ```bash
 # Clone this repository to your local machine
-git clone https://github.com/your-username/cafe-menu.git
+git clone https://github.com/tuhami-vc/cafe-menu.git
 
 # Navigate into the cloned directory
 cd cafe-menu


### PR DESCRIPTION
The "Getting Started" section of the README contained a non-functional, placeholder URL for cloning the repository. This would cause an error for anyone attempting to follow the setup instructions.

This commit replaces the placeholder with the actual, correct repository URL, ensuring the `git clone` command works as intended for all users.